### PR TITLE
Drop support for ruby 2.5 & support 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   relaxed-rubocop: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ os: linux
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.3
   - 2.6
   - 2.7
   - 3.0
+  - 3.1
   - ruby-head
 jobs:
   allow_failures:

--- a/prawn-label_sheet.gemspec
+++ b/prawn-label_sheet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency 'prawn'
 

--- a/prawn-label_sheet.gemspec
+++ b/prawn-label_sheet.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency 'prawn'
+  spec.add_dependency 'matrix'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
- Drop ruby 2.5 support
- Add matrix gem for prawn compatibility with 3.1
